### PR TITLE
Added OpenGraph metadata tags (#9)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,8 +7,8 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 
-	{% comment %} meta[0] is the key, meta[1] is the value{% endcomment %}
-	{% for meta in page.meta %}
+	{% comment %} og-metadata[0] is the key, og-metadata[1] is the value{% endcomment %}
+	{% for meta in page.og-metadata %}
 	<meta property="{{ meta[0] }}" content="{{ meta[1] }}" />
 	{% endfor %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,7 @@
 	{% for meta in page.og-metadata %}
 	<meta property="{{ meta[0] }}" content="{{ meta[1] }}" />
 	{% endfor %}
+	<meta property="og:type" content="website" />
 
 	{% for style in page.styles %}
 		<link rel='stylesheet' type='text/css' href="{{style}}"/>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,11 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 
+	{% comment %} meta[0] is the key, meta[1] is the value{% endcomment %}
+	{% for meta in page.meta %}
+	<meta property="{{ meta[0] }}" content="{{ meta[1] }}" />
+	{% endfor %}
+
 	{% for style in page.styles %}
 		<link rel='stylesheet' type='text/css' href="{{style}}"/>
 	{% endfor %}

--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 layout: default
 title: /risk
 active: pocetna
+og-metadata:
+  'og:title': RISK
+  'og:image': 'http://risk.matf.bg.ac.rs/assets/img/risk-light-logo.png'
 ---
 <div class="row">
     <div class='col-xs-12 col-md-8'>


### PR DESCRIPTION
This allows for metadata to be declared in the front-matter of a page, e.g.:
```
---
og-metadata:
  'og:title': RISK
  'og:image': 'http://risk.matf.bg.ac.rs/assets/img/risk-light-logo.png'
---
```
Resulting in the generated code:
```
<meta property="og:title" content="RISK" />
<meta property="og:image" content="http://risk.matf.bg.ac.rs/assets/img/risk-light-logo.png" />
<meta property="og:type" content="website" />
```
If no metadata is provided for a specific field, that field is omitted, making the metadata notation completely optional.

`og:type` value is hardcoded to be `website`, since we only use this metadata in web pages.
